### PR TITLE
feat(save-memory): add cluster field to save_memory tool

### DIFF
--- a/src/tools/save-memory.ts
+++ b/src/tools/save-memory.ts
@@ -9,6 +9,11 @@ export const saveMemorySchema = z.object({
   sessionId: z.string().describe('Session/conversation identifier'),
   projectPath: z.string().default('').describe('Absolute project path or empty for global'),
   metadata: z.record(z.unknown()).default({}).describe('Additional metadata'),
+  cluster: z
+    .string()
+    .regex(/^[a-z0-9-]{0,64}$/)
+    .default('')
+    .describe('Logical domain/subsystem (e.g. "auth-system", "payment-flow")'),
 });
 
 export async function handleSaveMemory(args: unknown) {


### PR DESCRIPTION
## Summary

- Adds optional `cluster` field to `save_memory` MCP tool Zod schema
- Validates against `/^[a-z0-9-]{0,64}$/` — empty string is allowed, defaults to `""`
- The value flows through to `saveMemory()` service, which already handles the `cluster` column in LanceDB (added in #2)

## Test plan

- [x] `npm run build` — clean compile, no type errors
- [x] `node --test test.mjs` — all 16 tests pass
- [ ] Manual: call `save_memory` with `cluster: "auth-system"` and verify it appears in `get_memory` response

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)