### PR TITLE
feat(search): add cluster pre-filter to search_memories

### DIFF
--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { getTable, rebuildFtsIndex, isFtsIndexed } from '../db/init.js';
 import { generateEmbedding, isEmbeddingAvailable } from './embedding.js';
+import { config } from '../config.js';
 import type {
   MemoryDocument,
   MemorySearchResult,
@@ -8,6 +9,7 @@ import type {
   SearchOptions,
   ResultOptions,
   TagCount,
+  RelatedId,
 } from '../types.js';
 
 // LanceDB applies a default limit of 10 to query().toArray() if no limit is set.
@@ -166,8 +168,11 @@ function rowToResult(row: Record<string, any>, opts: ResultOptions = {}): Memory
 }
 
 export async function saveMemory(
-  input: Omit<MemoryDocument, 'id' | 'embedding' | 'createdAt' | 'contentAndSummary' | 'cluster' | 'related_ids'> &
-    Partial<Pick<MemoryDocument, 'cluster' | 'related_ids'>>
+  input: Omit<MemoryDocument, 'id' | 'embedding' | 'createdAt' | 'contentAndSummary' | 'cluster' | 'related_ids'> & {
+    cluster?: string;
+    // Callers pass structured RelatedId objects; the service serializes to JSON for storage.
+    related_ids?: RelatedId[];
+  }
 ): Promise<string> {
   const table = await getTable();
   const id = uuidv4();
@@ -188,7 +193,7 @@ export async function saveMemory(
     metadata: JSON.stringify(input.metadata ?? {}),
     contentAndSummary,
     cluster: input.cluster ?? '',
-    related_ids: input.related_ids ?? '[]',
+    related_ids: input.related_ids ? JSON.stringify(input.related_ids) : '[]',
   };
 
   await table.add([row]);
@@ -217,27 +222,35 @@ export async function searchMemories(options: SearchOptions): Promise<{
   }
 
   const ro = options.resultOptions;
-  const where = buildWhereClause(options.filters);
+
+  // Apply AIBRAIN_DEFAULT_CLUSTER as a pre-filter when no explicit cluster is provided.
+  // Callers that pass filters.cluster always win; those that don't get the env default.
+  let filters = options.filters;
+  if (config.AIBRAIN_DEFAULT_CLUSTER && filters?.cluster === undefined) {
+    filters = { ...filters, cluster: config.AIBRAIN_DEFAULT_CLUSTER };
+  }
+
+  const where = buildWhereClause(filters);
 
   if (mode === 'fulltext') {
-    return fulltextSearch(options.query, limit, where, options.filters, ro);
+    return fulltextSearch(options.query, limit, where, filters, ro);
   }
 
   if (mode === 'vector') {
     const embedding = await generateEmbedding(options.query);
     if (embedding.length === 0) {
-      return fulltextSearch(options.query, limit, where, options.filters, ro);
+      return fulltextSearch(options.query, limit, where, filters, ro);
     }
-    return vectorSearch(embedding, limit, where, options.filters, ro);
+    return vectorSearch(embedding, limit, where, filters, ro);
   }
 
   // Hybrid: run both, merge with RRF
   const embedding = await generateEmbedding(options.query);
 
   const [bm25Results, vectorResults] = await Promise.all([
-    fulltextSearch(options.query, limit * 3, where, options.filters, ro),
+    fulltextSearch(options.query, limit * 3, where, filters, ro),
     embedding.length > 0
-      ? vectorSearch(embedding, limit * 3, where, options.filters, ro)
+      ? vectorSearch(embedding, limit * 3, where, filters, ro)
       : Promise.resolve({ results: [], totalFound: 0, searchMode: 'vector' }),
   ]);
 

--- a/src/tools/search-memories.ts
+++ b/src/tools/search-memories.ts
@@ -12,6 +12,7 @@ export const searchMemoriesSchema = z.object({
       tags: z.array(z.string()).optional(),
       since: z.string().optional().describe('ISO 8601 date'),
       until: z.string().optional().describe('ISO 8601 date'),
+      cluster: z.string().optional().describe('Cluster name to filter by (overrides AIBRAIN_DEFAULT_CLUSTER)'),
     })
     .optional(),
   searchMode: z.enum(['hybrid', 'fulltext', 'vector']).default('hybrid'),


### PR DESCRIPTION
## Summary

- Add `filters.cluster` field to the `search_memories` tool Zod schema so callers can explicitly pre-filter by cluster
- Apply `AIBRAIN_DEFAULT_CLUSTER` env var as a default cluster filter in `searchMemories` when no explicit cluster is provided — backward-compatible (no env var + no filter = all memories returned)
- Propagate the resolved filters object (with default cluster injected) through all downstream search code paths (`fulltextSearch`, `vectorSearch`, FTS post-filter via `matchesWhere`)
- Fix `saveMemory` type signature to accept `RelatedId[]` and serialize to JSON internally, resolving a type mismatch with the upgraded `save_memory` tool

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] `node --test test.mjs` — all 16 tests pass
- [ ] Manual: set `AIBRAIN_DEFAULT_CLUSTER=my-cluster`, call `search_memories` without `filters.cluster` — verify only memories with `cluster = "my-cluster"` are returned
- [ ] Manual: call `search_memories` with `filters.cluster = "other"` while `AIBRAIN_DEFAULT_CLUSTER=my-cluster` — verify explicit filter wins
- [ ] Manual: unset `AIBRAIN_DEFAULT_CLUSTER`, call without `filters.cluster` — verify all memories returned (backward-compatible)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)