### PR TITLE
feat: auto-link similar memories at save time

### DIFF
--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -223,6 +223,11 @@ export async function saveMemory(
     });
   }
 
+  // Fire-and-forget — do not block the save response
+  autoLink(id, embedding).catch((err) =>
+    console.error('[autoLink] failed silently:', err)
+  );
+
   // Schedule a debounced FTS index rebuild so the new row becomes searchable
   rebuildFtsIndex();
 
@@ -238,6 +243,70 @@ const REVERSE_RELATION: Record<string, RelatedId['relation_type']> = {
 
 function reverseRelationType(relationType: string): RelatedId['relation_type'] {
   return REVERSE_RELATION[relationType] ?? 'see-also';
+}
+
+/**
+ * Runs a vector similarity search against existing memories and creates
+ * bidirectional `similar` links for any candidates above the configured
+ * threshold. Called fire-and-forget after every save so it never adds
+ * latency to the caller.
+ *
+ * Manual links always take precedence: if any link of any relation type
+ * already exists between the two IDs, the auto-link is skipped.
+ */
+async function autoLink(newId: string, embedding: number[]): Promise<void> {
+  const AUTO_LINK_THRESHOLD = config.AIBRAIN_AUTO_LINK_THRESHOLD;
+  const AUTO_LINK_LIMIT = config.AIBRAIN_AUTO_LINK_LIMIT;
+
+  // Zero vectors indicate embedding is unavailable — skip auto-linking.
+  if (embedding.every((v) => v === 0)) return;
+
+  const table = await getTable();
+
+  const rows = await table
+    .vectorSearch(embedding)
+    .column('embedding')
+    .distanceType('cosine')
+    .limit(AUTO_LINK_LIMIT + 1)
+    .toArray();
+
+  const candidates = rows.filter((row: any) => row.id !== newId);
+
+  await Promise.all(
+    candidates.map(async (row: any) => {
+      const score = 1 - (row._distance ?? 1);
+      if (score < AUTO_LINK_THRESHOLD) return;
+
+      // Skip if any link already exists from the new memory to this candidate.
+      // appendRelatedIdIfAbsent handles the target side; we check the source side
+      // to respect manual links supplied at save time.
+      const sourceRows = await table
+        .query()
+        .where(`id = '${escapeSql(validateUuid(newId))}'`)
+        .limit(1)
+        .toArray();
+
+      if (sourceRows.length === 0) return;
+
+      let sourceLinks: RelatedId[] = [];
+      try {
+        sourceLinks =
+          typeof sourceRows[0].related_ids === 'string'
+            ? JSON.parse(sourceRows[0].related_ids)
+            : (sourceRows[0].related_ids ?? []);
+      } catch {
+        sourceLinks = [];
+      }
+
+      if (sourceLinks.some((r) => r.id === row.id)) return;
+
+      // Create bidirectional similar links.
+      await Promise.all([
+        appendRelatedIdIfAbsent(newId, { id: row.id, relation_type: 'similar' }),
+        appendRelatedIdIfAbsent(row.id, { id: newId, relation_type: 'similar' }),
+      ]);
+    })
+  );
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface MemoryDocument {
 
 export interface RelatedId {
   id: string;
-  relation_type: 'supersedes' | 'caused-by' | 'see-also' | 'follow-up';
+  relation_type: 'supersedes' | 'caused-by' | 'see-also' | 'follow-up' | 'similar';
 }
 
 export interface MemorySearchResult {


### PR DESCRIPTION
## Summary

- Adds `autoLink(newId, embedding)` which runs a cosine vector search after every `saveMemory` and creates bidirectional `similar` links for candidates above the similarity threshold
- Fires-and-forget (not awaited) — zero latency impact on `saveMemory`
- Manual links always take precedence: if any link already exists between two IDs, auto-link is skipped
- Threshold and limit are configurable via `AIBRAIN_AUTO_LINK_THRESHOLD` (default 0.85) and `AIBRAIN_AUTO_LINK_LIMIT` (default 3), which already existed in `config.ts` from Issue #2
- Adds `'similar'` to the `RelatedId.relation_type` union in `types.ts`
- No new API surface — entirely internal

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] `node --test test.mjs` — all 16 existing tests pass
- [ ] Manual: save two semantically similar memories and confirm both get `similar` links in `related_ids`
- [ ] Manual: save a memory with an explicit `related_ids` link to another — confirm auto-link does not overwrite it

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)