### PR TITLE
test: add comprehensive coverage for cluster, related_ids, and new tools

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -18,8 +18,15 @@ const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'aibrain-test-'));
 process.env.AIBRAIN_DATA_DIR = TEST_DIR;
 
 // Load services after env is set
-const { saveMemory, searchMemories, getRecentMemories, getMemoryById, deleteMemory } =
-  await import('./dist/services/memory.js');
+const {
+  saveMemory,
+  searchMemories,
+  getRecentMemories,
+  getMemoryById,
+  deleteMemory,
+  getRelatedMemories,
+  sanitizeFilterValue,
+} = await import('./dist/services/memory.js');
 const { generateEmbedding, isEmbeddingAvailable } =
   await import('./dist/services/embedding.js');
 const { config } = await import('./dist/config.js');
@@ -190,4 +197,376 @@ test('deleteMemory removes the memory', async () => {
 test('deleteMemory on unknown id returns success (idempotent)', async () => {
   const { success } = await deleteMemory('00000000-0000-0000-0000-000000000000');
   assert.equal(success, true);
+});
+
+// ── cluster ──────────────────────────────────────────────────────────────────
+
+// Cluster tests use their own isolated project path to avoid interference
+const CLUSTER_PROJECT = `/test-cluster-${Date.now()}`;
+
+let clusterMemId;
+
+test('saveMemory persists cluster value', async () => {
+  clusterMemId = await saveMemory({
+    content: 'Auth service refactored to use JWT tokens instead of sessions.',
+    summary: 'Auth refactor: JWT tokens',
+    tags: ['auth'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: CLUSTER_PROJECT,
+    metadata: {},
+    cluster: 'auth-system',
+  });
+  assert.match(clusterMemId, /^[0-9a-f-]{36}$/);
+
+  const mem = await getMemoryById(clusterMemId);
+  assert.ok(mem, 'memory should be retrievable');
+  assert.equal(mem.cluster, 'auth-system', 'cluster should be persisted');
+});
+
+test('saveMemory persists a second memory in a different cluster', async () => {
+  await saveMemory({
+    content: 'Payment flow updated to support multiple currencies via Stripe.',
+    summary: 'Payment: multi-currency support',
+    tags: ['payments'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: CLUSTER_PROJECT,
+    metadata: {},
+    cluster: 'payment-flow',
+  });
+  // Wait for FTS index rebuild before searching
+  await new Promise((r) => setTimeout(r, 1500));
+});
+
+test('search with cluster filter returns only matching cluster memories', async () => {
+  const { results } = await searchMemories({
+    query: 'auth payment',
+    searchMode: 'fulltext',
+    limit: 10,
+    filters: { projectPath: CLUSTER_PROJECT, cluster: 'auth-system' },
+  });
+  assert.ok(results.length > 0, 'should return results for auth-system cluster');
+  assert.ok(
+    results.every((r) => r.cluster === 'auth-system'),
+    'all results must belong to the auth-system cluster'
+  );
+});
+
+test('search without cluster filter returns memories from all clusters', async () => {
+  const { results } = await searchMemories({
+    query: 'auth payment',
+    searchMode: 'fulltext',
+    limit: 10,
+    filters: { projectPath: CLUSTER_PROJECT },
+  });
+  const clusters = new Set(results.map((r) => r.cluster).filter(Boolean));
+  assert.ok(clusters.size >= 2, 'should return memories from multiple clusters');
+});
+
+test('sanitizeFilterValue rejects cluster with uppercase letters', () => {
+  assert.throws(
+    () => sanitizeFilterValue('Auth-System', 'cluster'),
+    /must match/,
+    'uppercase letters should be rejected'
+  );
+});
+
+test('sanitizeFilterValue rejects cluster with special characters', () => {
+  assert.throws(
+    () => sanitizeFilterValue('auth_system!', 'cluster'),
+    /must match/,
+    'special characters should be rejected'
+  );
+});
+
+test('sanitizeFilterValue rejects cluster exceeding 64 characters', () => {
+  const longCluster = 'a'.repeat(65);
+  assert.throws(
+    () => sanitizeFilterValue(longCluster, 'cluster'),
+    /exceeds maximum length|must match/,
+    'cluster value over 64 chars should be rejected'
+  );
+});
+
+test('sanitizeFilterValue accepts valid cluster values', () => {
+  assert.doesNotThrow(() => sanitizeFilterValue('auth-system', 'cluster'));
+  assert.doesNotThrow(() => sanitizeFilterValue('payment-flow-2', 'cluster'));
+  assert.doesNotThrow(() => sanitizeFilterValue('abc123', 'cluster'));
+});
+
+// ── related_ids and back-linking ──────────────────────────────────────────────
+
+const RELATED_PROJECT = `/test-related-${Date.now()}`;
+
+let memoryAId;
+let memoryBId;
+
+test('saveMemory without related_ids defaults to empty', async () => {
+  memoryAId = await saveMemory({
+    content: 'Discovered a memory leak in the websocket connection pool.',
+    summary: 'Memory leak in websocket pool',
+    tags: ['bug'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: RELATED_PROJECT,
+    metadata: {},
+  });
+  assert.match(memoryAId, /^[0-9a-f-]{36}$/);
+
+  const mem = await getMemoryById(memoryAId);
+  assert.ok(mem, 'memory A should exist');
+  // related_ids should not be present or should be empty when not provided
+  const relatedIds = mem.related_ids ?? [];
+  assert.equal(relatedIds.length, 0, 'related_ids should default to empty');
+});
+
+test('saveMemory with related_ids stores forward links', async () => {
+  memoryBId = await saveMemory({
+    content: 'Fixed the memory leak in websocket pool by implementing connection lifecycle management.',
+    summary: 'Fixed websocket pool memory leak',
+    tags: ['bug-fix'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: RELATED_PROJECT,
+    metadata: {},
+    related_ids: [{ id: memoryAId, relation_type: 'caused-by' }],
+  });
+  assert.match(memoryBId, /^[0-9a-f-]{36}$/);
+
+  const memB = await getMemoryById(memoryBId);
+  assert.ok(memB, 'memory B should exist');
+  assert.ok(Array.isArray(memB.related_ids) && memB.related_ids.length > 0, 'B should have forward links');
+  assert.ok(
+    memB.related_ids.some((r) => r.id === memoryAId && r.relation_type === 'caused-by'),
+    'forward link to A with correct relation type should be stored'
+  );
+});
+
+test('back-links are created on referenced memory (fire-and-forget)', async () => {
+  // Wait for the fire-and-forget back-linking to complete
+  await new Promise((r) => setTimeout(r, 1500));
+
+  const memA = await getMemoryById(memoryAId);
+  assert.ok(memA, 'memory A should still exist');
+  const relatedIds = memA.related_ids ?? [];
+  assert.ok(
+    relatedIds.some((r) => r.id === memoryBId),
+    'A should have a back-link to B after fire-and-forget'
+  );
+});
+
+test('duplicate related_ids links are prevented', async () => {
+  // Save a third memory also pointing to A — the back-link on A from B should stay unique
+  await saveMemory({
+    content: 'Another fix attempt for the websocket leak.',
+    summary: 'Second websocket fix attempt',
+    tags: ['bug-fix'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: RELATED_PROJECT,
+    metadata: {},
+    related_ids: [{ id: memoryAId, relation_type: 'see-also' }],
+  });
+
+  await new Promise((r) => setTimeout(r, 1500));
+
+  const memA = await getMemoryById(memoryAId);
+  const linksToB = (memA.related_ids ?? []).filter((r) => r.id === memoryBId);
+  assert.equal(linksToB.length, 1, 'back-link to B should not be duplicated on A');
+});
+
+// ── get_related_memories ──────────────────────────────────────────────────────
+
+test('getRelatedMemories depth 1 returns only direct links', async () => {
+  const result = await getRelatedMemories(memoryBId, 1);
+  assert.ok(result.root, 'should have a root node');
+  assert.equal(result.root.id, memoryBId);
+  assert.ok(Array.isArray(result.nodes), 'nodes should be an array');
+  // Depth 1: only immediate neighbors
+  assert.ok(result.nodes.every((n) => n.depth === 1), 'all nodes should be at depth 1');
+  assert.ok(
+    result.nodes.some((n) => n.id === memoryAId),
+    'direct link to A should appear at depth 1'
+  );
+});
+
+test('getRelatedMemories depth 2 returns links of links', async () => {
+  // Set up a chain: C -> B -> A
+  const memoryCId = await saveMemory({
+    content: 'Deployed the websocket pool fix to production.',
+    summary: 'Deployed websocket fix to production',
+    tags: ['deployment'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: RELATED_PROJECT,
+    metadata: {},
+    related_ids: [{ id: memoryBId, relation_type: 'follow-up' }],
+  });
+
+  await new Promise((r) => setTimeout(r, 500));
+
+  const result = await getRelatedMemories(memoryCId, 2);
+  assert.ok(result.root, 'should have a root');
+  assert.equal(result.root.id, memoryCId);
+
+  const depth1Ids = result.nodes.filter((n) => n.depth === 1).map((n) => n.id);
+  const depth2Ids = result.nodes.filter((n) => n.depth === 2).map((n) => n.id);
+
+  assert.ok(depth1Ids.includes(memoryBId), 'B should appear at depth 1');
+  // A is a link of B, so it should appear at depth 2
+  assert.ok(depth2Ids.includes(memoryAId), 'A should appear at depth 2');
+});
+
+test('getRelatedMemories handles cycles without infinite loops', async () => {
+  // Create two memories that link to each other via back-linking
+  const cycleProject = `/test-cycle-${Date.now()}`;
+
+  const cycleAId = await saveMemory({
+    content: 'Cycle memory A for cycle detection test.',
+    summary: 'Cycle memory A',
+    tags: ['test'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: cycleProject,
+    metadata: {},
+  });
+
+  const cycleBId = await saveMemory({
+    content: 'Cycle memory B linking back to A to form a cycle.',
+    summary: 'Cycle memory B',
+    tags: ['test'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: cycleProject,
+    metadata: {},
+    related_ids: [{ id: cycleAId, relation_type: 'see-also' }],
+  });
+
+  // Wait for back-link from B->A to be established on A (fire-and-forget)
+  await new Promise((r) => setTimeout(r, 1500));
+
+  // Now A links to B (via back-link) and B links to A — a cycle
+  // getRelatedMemories should terminate without infinite recursion
+  const result = await getRelatedMemories(cycleAId, 3);
+  assert.ok(result.root, 'should return a root');
+  // The important invariant: each ID appears at most once in nodes.
+  const ids = result.nodes.map((n) => n.id);
+  const uniqueIds = new Set(ids);
+  assert.equal(ids.length, uniqueIds.size, 'no node ID should appear more than once (cycle-safe)');
+});
+
+test('getRelatedMemories returns error for non-existent root ID', async () => {
+  const result = await getRelatedMemories('00000000-0000-0000-0000-000000000000', 1);
+  assert.equal(result.root, null, 'root should be null for unknown ID');
+  assert.ok(result.error, 'should include an error message');
+  assert.ok(Array.isArray(result.nodes) && result.nodes.length === 0, 'nodes should be empty');
+});
+
+// ── include_related on search_memories ───────────────────────────────────────
+
+test('searchMemories without include_related returns results without related field', async () => {
+  await new Promise((r) => setTimeout(r, 500));
+
+  const { results } = await searchMemories({
+    query: 'websocket memory leak',
+    searchMode: 'fulltext',
+    limit: 5,
+    filters: { projectPath: RELATED_PROJECT },
+    include_related: false,
+  });
+  assert.ok(results.length > 0, 'should return results');
+  // No result should have a related field when include_related is false
+  assert.ok(
+    results.every((r) => r.related === undefined),
+    'results should not have a related field when include_related is false'
+  );
+});
+
+test('searchMemories with include_related augments results with related summaries', async () => {
+  // Save a "context" memory that will NOT appear in the search results (unique term).
+  // Then save a "result" memory that links to it and will appear in results.
+  // BFS enriches the result memory with the context memory's summary.
+  const includeRelatedProject = `/test-include-related-${Date.now()}`;
+
+  const contextMemId = await saveMemory({
+    content: 'Underlying architecture uses an event-sourcing pattern for the order pipeline.',
+    summary: 'Order pipeline uses event-sourcing',
+    tags: ['architecture'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: includeRelatedProject,
+    metadata: {},
+  });
+
+  await saveMemory({
+    content: 'Optimized order processing throughput by batching database writes.',
+    summary: 'Order processing throughput optimized',
+    tags: ['performance'],
+    agentName: 'test-agent',
+    sessionId: 'test-session',
+    projectPath: includeRelatedProject,
+    metadata: {},
+    related_ids: [{ id: contextMemId, relation_type: 'see-also' }],
+  });
+
+  // Wait for FTS index rebuild and back-linking
+  await new Promise((r) => setTimeout(r, 1500));
+
+  // Query targets only the performance memory; context memory won't match this query
+  const { results } = await searchMemories({
+    query: 'throughput optimized batching database writes',
+    searchMode: 'fulltext',
+    limit: 5,
+    filters: { projectPath: includeRelatedProject },
+    include_related: true,
+    related_depth: 1,
+  });
+  assert.ok(results.length > 0, 'should return results');
+
+  // The performance memory should appear and be augmented with the context memory summary
+  const augmented = results.filter(
+    (r) => Array.isArray(r.related) && r.related.length > 0
+  );
+  assert.ok(augmented.length > 0, 'result with related_ids not in result set should be augmented');
+
+  // Each related summary should have the required fields
+  for (const result of augmented) {
+    for (const rel of result.related) {
+      assert.ok(rel.id, 'related summary should have id');
+      assert.ok(rel.summary, 'related summary should have summary');
+      assert.ok(rel.relation_type, 'related summary should have relation_type');
+      assert.ok(typeof rel.depth === 'number', 'related summary should have depth');
+    }
+  }
+});
+
+// ── filter safety ─────────────────────────────────────────────────────────────
+
+test('getMemoryById returns null for non-UUID id', async () => {
+  // validateUuid throws internally; getMemoryById catches and returns null
+  const result = await getMemoryById('not-a-uuid');
+  assert.equal(result, null, 'non-UUID id should return null');
+});
+
+test('sanitizeFilterValue rejects values with control characters', () => {
+  assert.throws(
+    () => sanitizeFilterValue('valid\x00injection', 'projectPath'),
+    /control characters/,
+    'null byte should be rejected'
+  );
+  assert.throws(
+    () => sanitizeFilterValue('value\x1fwith-control', 'agentName'),
+    /control characters/,
+    'control character U+001F should be rejected'
+  );
+});
+
+test('sanitizeFilterValue rejects projectPath exceeding max length', () => {
+  const longPath = '/a'.repeat(2049);
+  assert.throws(
+    () => sanitizeFilterValue(longPath, 'projectPath'),
+    /exceeds maximum length/,
+    'projectPath over 4096 chars should be rejected'
+  );
 });


### PR DESCRIPTION
## Summary

- Adds 21 new integration tests to `test.mjs` covering all features from Issues #2–#10
- Also imports `getRelatedMemories` and `sanitizeFilterValue` directly from `dist/services/memory.js` for precise assertions without MCP tool layer overhead

### Test areas covered

**Cluster functionality**
- `saveMemory` persists `cluster` value; `getMemoryById` returns it
- Search with `cluster` filter returns only matching cluster memories
- Search without `cluster` filter returns all clusters (backward compat)
- `sanitizeFilterValue` rejects uppercase, special chars, and values >64 chars

**Related IDs and back-linking**
- `saveMemory` without `related_ids` defaults to empty array
- Forward links stored with correct `relation_type`
- Bidirectional back-links created via fire-and-forget; verified with `setTimeout`
- Duplicate links prevented: repeated back-linking leaves exactly one link per pair

**`get_related_memories` tool**
- Depth 1: only direct neighbors returned (all `depth === 1`)
- Depth 2: transitive links at depth 2 discovered correctly
- Cycle safety: BFS `visited` set prevents any node appearing more than once
- Non-existent root returns `root: null`, non-empty `error`, and empty `nodes`

**`include_related` on `search_memories`**
- `include_related: false` produces no `related` field on any result
- `include_related: true` augments results whose related memories are NOT already in the result set (BFS skips seed IDs by design); each related summary has `id`, `summary`, `relation_type`, and `depth`

**Filter safety**
- `getMemoryById` with a non-UUID returns `null` (internal throw caught)
- `sanitizeFilterValue` rejects control characters (`\x00`, `\x1f`)
- `sanitizeFilterValue` rejects `projectPath` over 4096 chars

## Test plan

- [x] `npm run build` succeeds with no TypeScript errors
- [x] `node --test test.mjs` — all 37 tests pass (16 original + 21 new)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)